### PR TITLE
修复require本地文件bug

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -28,7 +28,7 @@ class ScriptCatWebpackPlugin {
 		if (!compiler) {
 			return;
 		}
-		compiler.hooks.emit.tap("ScriptCatWebpackPlugin", (compilation, compilationParams) => {
+		compiler.hooks.done.tap("ScriptCatWebpackPlugin", ({compilation}) => {
 			if (this.options?.file && compilation.assets[this.options.file]) {
 				/**
 				 * @var {{ [key: string]: string[] | string }} metadata
@@ -55,11 +55,10 @@ class ScriptCatWebpackPlugin {
 					});
 					requireFile += "\n"
 				}
-				let content = this.align(metadata) + requireFile + userConfig + compilation.assets[this.options.file].source();
-				compilation.assets[this.options.file] = {
-					source: () => content,
-					size: () => content.length
-				};
+				const filePath = compilation.outputOptions.path + '/' + this.options.file;
+				const source = fs.readFileSync(filePath, "utf-8");
+				const content = this.align(metadata) + requireFile + userConfig + source;
+				fs.writeFileSync(filePath, content);
 			}
 		});
 	}


### PR DESCRIPTION
原emit钩子存在BUG：先require本地文件，后编译，会导致require的本地文件是旧文件。
因此需要将钩子从emit移至done，等待文件编译完后再require本地文件，保证本地文件为编译后的新文件。
（建议编译前应先清理旧文件，防止代码混乱）


